### PR TITLE
Making sure prewrapped files with comments don't get re-wrapped.

### DIFF
--- a/lib/amd-wrap-legacy.js
+++ b/lib/amd-wrap-legacy.js
@@ -8,7 +8,8 @@ var RE = {
 
 RE.alreadyAmd = new RegExp(
     RE.alreadyWrapped.source + "|" +
-    RE.windowStyle.source
+    RE.windowStyle.source,
+    "m"
 );
 
 module.exports = function (sourceText) {

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,7 @@ specify("It doesn't re-wrap when the string has a define that is just a literal"
     assert.strictEqual(output, input);
 });
 
-xspecify("It doesn't re-wrap when the string is already wrapped, with comments at top", function () {
+specify("It doesn't re-wrap when the string is already wrapped, with comments at top", function () {
     var input = fs.readFileSync(path.resolve(__dirname, "fixtures/prewrappedWithComments.js"), "utf-8");
     var output = amdWrap(input);
 


### PR DESCRIPTION
We ran into a problem where pre-wrapped files with leading comments would get double wrapped, and I noticed this test was failing.

Setting the multiline modifier (as used previously with the `alreadyAmd` and `windowStyle` regexes) resolved the problem.
